### PR TITLE
Could create too many handler references everytime the user clicks. 

### DIFF
--- a/app/src/main/java/com/pedromassango/doubleclick/DoubleClick.java
+++ b/app/src/main/java/com/pedromassango/doubleclick/DoubleClick.java
@@ -26,7 +26,7 @@ public class DoubleClick implements View.OnClickListener {
 
             // Increase clicks count
             this.clicks++;
-            long TIME_TO_LISTEN_A_DOUBLE_CLICK = 250L;  // Time to wait the second click.
+            long DOUBLE_CLICK_INTERVAL = 250L;  // Time to wait the second click.
             mHandler.postDelayed(new Runnable() {
                 public final void run() {
 
@@ -42,7 +42,7 @@ public class DoubleClick implements View.OnClickListener {
                     clicks = 0;
                     isBussy = false;
                 }
-            }, TIME_TO_LISTEN_A_DOUBLE_CLICK);
+            }, DOUBLE_CLICK_INTERVAL);
         }
     }
 }

--- a/app/src/main/java/com/pedromassango/doubleclick/DoubleClick.java
+++ b/app/src/main/java/com/pedromassango/doubleclick/DoubleClick.java
@@ -12,7 +12,7 @@ public class DoubleClick implements View.OnClickListener {
     private int clicks;
     private boolean isBussy = false;
     private final DoubleClickListener doubleClickListener;
-
+    Handler mHandler = new Handler();
     public DoubleClick( DoubleClickListener doubleClickListener) {
         this.doubleClickListener = doubleClickListener;
     }
@@ -26,10 +26,8 @@ public class DoubleClick implements View.OnClickListener {
 
             // Increase clicks count
             this.clicks++;
-            Handler handler = new Handler();
             long TIME_TO_LISTEN_A_DOUBLE_CLICK = 250L;  // Time to wait the second click.
-
-            handler.postDelayed(new Runnable() {
+            mHandler.postDelayed(new Runnable() {
                 public final void run() {
 
                     if (clicks >= 2) {  // Double tap.


### PR DESCRIPTION
Allow the class to only have one instance of a handler. The code created a new handler every time a user clicked on the View. This would create several handler references each associated with the current threads messageQueue, which is inefficient. Also used a more descriptive variable name.